### PR TITLE
Change default and maximum limit for report retrieval

### DIFF
--- a/src/toolsets/get-daily-reports-toolset.ts
+++ b/src/toolsets/get-daily-reports-toolset.ts
@@ -73,12 +73,12 @@ export const dailyReportsTool = {
       limit: z
         .number()
         .min(1)
-        .max(100)
+        .max(500)
         .optional()
         .describe(
           formatEnJaWithSlash(
-            'Number of results to retrieve (default: 20, max: 100)',
-            '取得件数 (デフォルト:20, 最大:100)',
+            'Number of results to retrieve (default: 100, max: 500)',
+            '取得件数 (デフォルト:100, 最大:500)',
           ),
         ),
     },


### PR DESCRIPTION
Update the default limit for retrieving driving report summaries to 100 and increase the maximum limit to 500. This change enhances the flexibility of data retrieval.