### PR TITLE
fix: resolve npm audit vulnerabilities by replacing axios with fetch API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",
-        "axios": "^1.7.7",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -106,9 +105,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -123,9 +122,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -140,9 +139,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -157,9 +156,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -174,9 +173,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -191,9 +190,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -208,9 +207,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -225,9 +224,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -242,9 +241,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -259,9 +258,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -276,9 +275,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -293,9 +292,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -310,9 +309,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -327,9 +326,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -344,9 +343,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -361,9 +360,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -378,9 +377,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -395,9 +394,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -412,9 +411,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -429,9 +428,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -446,9 +445,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -463,9 +462,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -480,9 +479,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -497,9 +496,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -514,9 +513,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -531,9 +530,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -592,9 +591,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -603,9 +602,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -663,9 +662,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -684,9 +683,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -731,6 +730,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -874,11 +885,12 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.21.1.tgz",
-      "integrity": "sha512-UyLFcJLDvUuZbGnaQqXFT32CpPpGj7VS19roLut6gkQVhb439xUzYWbsUvdI3ZPL+2hnFosuugtYWE0Mcs1rmQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -886,29 +898,36 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1"
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
         "@cfworker/json-schema": {
           "optional": true
+        },
+        "zod": {
+          "optional": false
         }
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -984,9 +1003,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
-      "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -998,9 +1017,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
-      "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -1012,9 +1031,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
-      "integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -1026,9 +1045,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
-      "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -1040,9 +1059,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
-      "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -1054,9 +1073,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
-      "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -1068,9 +1087,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
-      "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -1082,9 +1101,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
-      "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -1096,9 +1115,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
-      "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -1110,9 +1129,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
-      "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -1123,10 +1142,24 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
-      "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
@@ -1138,9 +1171,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
-      "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -1152,9 +1199,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
-      "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -1166,9 +1213,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
-      "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -1180,9 +1227,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
-      "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -1194,9 +1241,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
-      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -1208,9 +1255,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
-      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -1221,10 +1268,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
-      "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -1236,9 +1311,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
-      "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -1249,10 +1324,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
-      "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -1757,9 +1846,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1791,9 +1880,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1870,23 +1959,6 @@
         "js-tokens": "^9.0.1"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1895,29 +1967,33 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2072,18 +2148,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2092,15 +2156,16 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -2158,9 +2223,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2190,15 +2255,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2289,25 +2345,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/esbuild": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2318,32 +2359,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.9",
-        "@esbuild/android-arm": "0.25.9",
-        "@esbuild/android-arm64": "0.25.9",
-        "@esbuild/android-x64": "0.25.9",
-        "@esbuild/darwin-arm64": "0.25.9",
-        "@esbuild/darwin-x64": "0.25.9",
-        "@esbuild/freebsd-arm64": "0.25.9",
-        "@esbuild/freebsd-x64": "0.25.9",
-        "@esbuild/linux-arm": "0.25.9",
-        "@esbuild/linux-arm64": "0.25.9",
-        "@esbuild/linux-ia32": "0.25.9",
-        "@esbuild/linux-loong64": "0.25.9",
-        "@esbuild/linux-mips64el": "0.25.9",
-        "@esbuild/linux-ppc64": "0.25.9",
-        "@esbuild/linux-riscv64": "0.25.9",
-        "@esbuild/linux-s390x": "0.25.9",
-        "@esbuild/linux-x64": "0.25.9",
-        "@esbuild/netbsd-arm64": "0.25.9",
-        "@esbuild/netbsd-x64": "0.25.9",
-        "@esbuild/openbsd-arm64": "0.25.9",
-        "@esbuild/openbsd-x64": "0.25.9",
-        "@esbuild/openharmony-arm64": "0.25.9",
-        "@esbuild/sunos-x64": "0.25.9",
-        "@esbuild/win32-arm64": "0.25.9",
-        "@esbuild/win32-ia32": "0.25.9",
-        "@esbuild/win32-x64": "0.25.9"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-html": {
@@ -2473,9 +2514,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2507,9 +2548,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2647,18 +2688,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -2689,10 +2731,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -2813,9 +2858,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -2826,7 +2871,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -2861,31 +2910,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -2902,43 +2931,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -3021,9 +3013,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3108,21 +3101,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3135,6 +3113,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3143,40 +3130,39 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -3221,6 +3207,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -3356,6 +3351,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -3364,9 +3368,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3389,6 +3393,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3560,25 +3570,29 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3816,12 +3830,13 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3849,9 +3864,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3938,12 +3953,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3955,9 +3964,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4000,18 +4009,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/require-from-string": {
@@ -4045,9 +4054,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
-      "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4061,26 +4070,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.46.2",
-        "@rollup/rollup-android-arm64": "4.46.2",
-        "@rollup/rollup-darwin-arm64": "4.46.2",
-        "@rollup/rollup-darwin-x64": "4.46.2",
-        "@rollup/rollup-freebsd-arm64": "4.46.2",
-        "@rollup/rollup-freebsd-x64": "4.46.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.46.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.46.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.46.2",
-        "@rollup/rollup-linux-arm64-musl": "4.46.2",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.46.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.46.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.46.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.46.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.46.2",
-        "@rollup/rollup-linux-x64-gnu": "4.46.2",
-        "@rollup/rollup-linux-x64-musl": "4.46.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.46.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.46.2",
-        "@rollup/rollup-win32-x64-msvc": "4.46.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -4124,26 +4138,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4164,31 +4158,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -4198,6 +4196,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -4247,13 +4249,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4540,14 +4542,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4575,9 +4577,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4739,18 +4741,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.2.tgz",
-      "integrity": "sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.6",
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4855,9 +4857,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4941,9 +4943,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5119,12 +5121,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@cariot-labs/cariot-mcp-server",
   "version": "1.2.2",
   "description": "MCP server for Cariot",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "main": "dist/index.js",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.21.1",
-    "axios": "^1.7.7",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.2",
   "description": "MCP server for Cariot",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.18.0"
   },
   "main": "dist/index.js",
   "type": "module",

--- a/src/api/api-utils.ts
+++ b/src/api/api-utils.ts
@@ -1,10 +1,9 @@
-import { FetchClient, FetchRequestConfig } from '../lib/http-client.js';
+import { FetchClient } from '../lib/http-client.js';
 
 export const API_BASE = process.env.CARIOT_API_BASE_URL || 'https://api.cariot.jp/api';
 
 export async function get<T>(client: FetchClient, url: string, params?: unknown): Promise<T> {
-  const config: FetchRequestConfig = params ? { params: params as Record<string, unknown> } : {};
-  const response = await client.get<T>(url, config);
+  const response = await client.get<T>(url, { params });
   return response.data;
 }
 

--- a/src/api/api-utils.ts
+++ b/src/api/api-utils.ts
@@ -1,6 +1,6 @@
 import { FetchClient, FetchRequestConfig } from '../lib/http-client.js';
 
-export const API_BASE = process.env.CARIOT_API_BASE_URL || 'https://api.dev.cariot.jp/api';
+export const API_BASE = process.env.CARIOT_API_BASE_URL || 'https://api.cariot.jp/api';
 
 export async function get<T>(client: FetchClient, url: string, params?: unknown): Promise<T> {
   const config: FetchRequestConfig = params ? { params: params as Record<string, unknown> } : {};

--- a/src/api/api-utils.ts
+++ b/src/api/api-utils.ts
@@ -1,13 +1,14 @@
-import { AxiosInstance } from 'axios';
+import { FetchClient, FetchRequestConfig } from '../lib/http-client.js';
 
-export const API_BASE = process.env.CARIOT_API_BASE_URL || 'https://api.cariot.jp/api';
+export const API_BASE = process.env.CARIOT_API_BASE_URL || 'https://api.dev.cariot.jp/api';
 
-export async function get<T>(client: AxiosInstance, url: string, params?: unknown): Promise<T> {
-  const response = await client.get<T>(url, { params });
+export async function get<T>(client: FetchClient, url: string, params?: unknown): Promise<T> {
+  const config: FetchRequestConfig = params ? { params: params as Record<string, unknown> } : {};
+  const response = await client.get<T>(url, config);
   return response.data;
 }
 
-export async function post<T>(client: AxiosInstance, url: string, data?: unknown): Promise<T> {
+export async function post<T>(client: FetchClient, url: string, data?: unknown): Promise<T> {
   const response = await client.post<T>(url, data);
   return response.data;
 }

--- a/src/api/get-daily-report.ts
+++ b/src/api/get-daily-report.ts
@@ -1,11 +1,11 @@
-import { AxiosInstance } from 'axios';
+import { FetchClient } from '../lib/http-client.js';
 import { API_BASE, get } from './api-utils.js';
 import { DailyReportQuery, GetDailyReportResponse } from './types/get-daily-report.js';
 
 const PATH = '/daily_reports/report_no/:daily_report_no';
 
 export async function getDailyReport(
-  client: AxiosInstance,
+  client: FetchClient,
   params: DailyReportQuery,
 ): Promise<GetDailyReportResponse> {
   const url = `${API_BASE}${PATH.replace(':daily_report_no', params.daily_report_no)}`;

--- a/src/api/get-daily-reports.ts
+++ b/src/api/get-daily-reports.ts
@@ -1,11 +1,11 @@
-import { AxiosInstance } from 'axios';
+import { FetchClient } from '../lib/http-client.js';
 import { API_BASE, get } from './api-utils.js';
 import { DailyReportsQuery, GetDailyReportsListResponse } from './types/get-daily-reports.js';
 
 const PATH = '/daily_reports';
 
 export async function getDailyReports(
-  client: AxiosInstance,
+  client: FetchClient,
   params: DailyReportsQuery,
 ): Promise<GetDailyReportsListResponse> {
   const url = `${API_BASE}${PATH}`;

--- a/src/api/get-device-snapshots.ts
+++ b/src/api/get-device-snapshots.ts
@@ -1,11 +1,11 @@
-import { AxiosInstance } from 'axios';
+import { FetchClient } from '../lib/http-client.js';
 import { API_BASE, get } from './api-utils.js';
 import { DeviceSnapshotQuery, GetDeviceSnapshotsResponse } from './types/get-device-snapshots.js';
 
 const PATH = '/device_snapshots';
 
 export async function getDeviceSnapshots(
-  client: AxiosInstance,
+  client: FetchClient,
   params: DeviceSnapshotQuery,
 ): Promise<GetDeviceSnapshotsResponse> {
   const url = `${API_BASE}${PATH}`;

--- a/src/api/get-drivers.ts
+++ b/src/api/get-drivers.ts
@@ -1,11 +1,11 @@
-import { AxiosInstance } from 'axios';
+import { FetchClient } from '../lib/http-client.js';
 import { API_BASE, get } from './api-utils.js';
 import { DriversQuery, GetDriversListResponse } from './types/get-drivers.js';
 
 const PATH = '/drivers';
 
 export async function getDrivers(
-  client: AxiosInstance,
+  client: FetchClient,
   params: DriversQuery,
 ): Promise<GetDriversListResponse> {
   const url = `${API_BASE}${PATH}`;

--- a/src/api/get-vehicles.ts
+++ b/src/api/get-vehicles.ts
@@ -1,11 +1,11 @@
-import { AxiosInstance } from 'axios';
+import { FetchClient } from '../lib/http-client.js';
 import { API_BASE, get } from './api-utils.js';
 import { GetVehiclesListResponse, VehiclesQuery } from './types/get-vehicles.js';
 
 const PATH = '/vehicles';
 
 export async function getVehicles(
-  client: AxiosInstance,
+  client: FetchClient,
   params: VehiclesQuery,
 ): Promise<GetVehiclesListResponse> {
   const url = `${API_BASE}${PATH}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,6 @@ const authProvider = CariotApiAuthProvider.createCariotAuthProvider();
 const server = new McpServer({
   name: 'cariot',
   version: '1.0.0',
-  capabilities: {
-    resources: {},
-    tools: {},
-  },
 });
 
 registerAllTools(server, authProvider);

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -1,12 +1,6 @@
-import axios, {
-  AxiosError,
-  AxiosHeaders,
-  AxiosInstance,
-  AxiosRequestConfig,
-  AxiosResponse,
-} from 'axios';
 import { API_BASE } from '../api/api-utils.js';
 import { getEnvironment } from './env.js';
+import { FetchClient, FetchClientError, FetchRequestConfig, FetchResponse } from './http-client.js';
 import { logger } from './logger.js';
 import { ApiAuthResponse, ApiCredentials } from './types.js';
 
@@ -14,61 +8,93 @@ type AuthConfig =
   | { type: 'id_token'; idToken: string; loginUrl: string }
   | { type: 'api_key'; credentials: ApiCredentials; loginUrl: string };
 
-export class CariotApiAuthProvider {
-  private token: string | null = null;
-  private authConfig: AuthConfig;
-  private client: AxiosInstance;
+/**
+ * Authenticated HTTP client that wraps FetchClient with token management
+ */
+export class AuthenticatedFetchClient extends FetchClient {
+  private authProvider: CariotApiAuthProvider;
 
-  constructor(authConfig: AuthConfig) {
-    this.authConfig = authConfig;
-    this.client = axios.create({
+  constructor(authProvider: CariotApiAuthProvider) {
+    super({
       timeout: 15000,
       headers: {
         'Content-Type': 'application/json',
       },
     });
+    this.authProvider = authProvider;
+  }
 
-    this.client.interceptors.request.use(async (config) => {
-      const token = await this.getValidToken();
-      let headersObj: AxiosHeaders;
-      if (config.headers instanceof AxiosHeaders) {
-        headersObj = config.headers;
-      } else {
-        headersObj = new AxiosHeaders(config.headers as Record<string, string | number | boolean>);
-      }
-      headersObj.set('x-auth-token', token);
-      headersObj.set('Content-Type', 'application/json');
-      config.headers = headersObj;
-      logger.info('HTTP request', {
-        url: config.url,
-        method: config.method,
-        params: config.params,
-      });
-      return config;
+  private async executeWithAuth<T>(
+    method: 'GET' | 'POST',
+    url: string,
+    data?: unknown,
+    config: FetchRequestConfig = {},
+  ): Promise<FetchResponse<T>> {
+    const token = await this.authProvider.getValidToken();
+    const headers = {
+      ...config.headers,
+      'x-auth-token': token,
+      'Content-Type': 'application/json',
+    };
+
+    logger.info('HTTP request', {
+      url,
+      method,
+      params: config.params,
     });
 
-    this.client.interceptors.response.use(
-      (response) => response,
-      async (error) => {
-        const axiosError = error as AxiosError;
-        const originalConfig = axiosError.config as AxiosRequestConfig & { _retry?: boolean };
-        if (axiosError.response?.status === 401 && originalConfig && !originalConfig._retry) {
-          logger.warn('Received 401, attempting re-authentication');
-          this.token = null;
-          const newToken = await this.getValidToken();
-          originalConfig._retry = true;
-          originalConfig.headers = {
-            ...(originalConfig.headers ?? {}),
-            'x-auth-token': newToken,
-          };
-          return this.client.request(originalConfig);
+    try {
+      if (method === 'GET') {
+        return await super.get<T>(url, { ...config, headers });
+      } else {
+        return await super.post<T>(url, data, { ...config, headers });
+      }
+    } catch (error) {
+      if (error instanceof FetchClientError && error.status === 401 && !config._retry) {
+        logger.warn('Received 401, attempting re-authentication');
+        this.authProvider.clearToken();
+        const newToken = await this.authProvider.getValidToken();
+
+        const retryHeaders = {
+          ...config.headers,
+          'x-auth-token': newToken,
+          'Content-Type': 'application/json',
+        };
+
+        if (method === 'GET') {
+          return await super.get<T>(url, { ...config, headers: retryHeaders, _retry: true });
+        } else {
+          return await super.post<T>(url, data, { ...config, headers: retryHeaders, _retry: true });
         }
-        logger.error('API request failed', {
-          error: axiosError.message,
-        });
-        return Promise.reject(axiosError);
-      },
-    );
+      }
+
+      logger.error('API request failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  async get<T>(url: string, config?: FetchRequestConfig): Promise<FetchResponse<T>> {
+    return this.executeWithAuth<T>('GET', url, undefined, config);
+  }
+
+  async post<T>(
+    url: string,
+    data?: unknown,
+    config?: FetchRequestConfig,
+  ): Promise<FetchResponse<T>> {
+    return this.executeWithAuth<T>('POST', url, data, config);
+  }
+}
+
+export class CariotApiAuthProvider {
+  private token: string | null = null;
+  private authConfig: AuthConfig;
+  private client: AuthenticatedFetchClient | null = null;
+
+  constructor(authConfig: AuthConfig) {
+    this.authConfig = authConfig;
   }
 
   async getValidToken(): Promise<string> {
@@ -79,43 +105,65 @@ export class CariotApiAuthProvider {
     return await this.fetchToken();
   }
 
+  clearToken(): void {
+    this.token = null;
+  }
+
   private async fetchToken(): Promise<string> {
     try {
       logger.debug('Fetching authentication token', { authType: this.authConfig.type });
 
-      let response: AxiosResponse<ApiAuthResponse>;
+      const controller = new AbortController();
+      const timeoutId = globalThis.setTimeout(() => controller.abort(), 15000);
+
+      let response: Response;
 
       if (this.authConfig.type === 'id_token') {
-        // Use id token with /api/login/cariot endpoint
-        response = await axios.post(
-          this.authConfig.loginUrl,
-          {},
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${this.authConfig.idToken}`,
-            },
-            timeout: 15000,
+        response = await fetch(this.authConfig.loginUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.authConfig.idToken}`,
           },
-        );
+          body: JSON.stringify({}),
+          signal: controller.signal,
+        });
       } else {
-        // Use API key credentials with /api/login endpoint
-        response = await axios.post(this.authConfig.loginUrl, this.authConfig.credentials, {
-          headers: { 'Content-Type': 'application/json' },
-          timeout: 15000,
+        response = await fetch(this.authConfig.loginUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(this.authConfig.credentials),
+          signal: controller.signal,
         });
       }
 
-      this.token = response.data.api_token;
+      globalThis.clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => 'Unable to read response body');
+        logger.error('Authentication failed', {
+          status: response.status,
+          statusText: response.statusText,
+          body: errorBody,
+          loginUrl: this.authConfig.loginUrl,
+        });
+        throw new Error(`Authentication request failed with status ${response.status}: ${errorBody}`);
+      }
+
+      const data = (await response.json()) as ApiAuthResponse;
+      this.token = data.api_token;
 
       logger.debug('Authentication token fetched successfully');
       return this.token;
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error('Error fetching token', {
-        error: error instanceof Error ? error.message : String(error),
+        error: errorMessage,
         authType: this.authConfig.type,
       });
-      throw new Error('Failed to authenticate with external API');
+      throw new Error(`Failed to authenticate with external API: ${errorMessage}`);
     }
   }
 
@@ -143,7 +191,10 @@ export class CariotApiAuthProvider {
     }
   }
 
-  getAuthedClient(): AxiosInstance {
+  getAuthedClient(): FetchClient {
+    if (!this.client) {
+      this.client = new AuthenticatedFetchClient(this);
+    }
     return this.client;
   }
 }

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -141,11 +141,13 @@ export class CariotApiAuthProvider {
 
       if (!response.ok) {
         const errorBody = await response.text().catch(() => 'Unable to read response body');
+        // Truncate body to avoid leaking sensitive data in logs
+        const truncatedBody =
+          errorBody.length > 100 ? `${errorBody.substring(0, 100)}...[truncated]` : errorBody;
         logger.error('Authentication failed', {
           status: response.status,
           statusText: response.statusText,
-          body: errorBody,
-          loginUrl: this.authConfig.loginUrl,
+          body: truncatedBody,
         });
         throw new Error(
           `Authentication request failed with status ${response.status}: ${errorBody}`,

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -61,10 +61,17 @@ export class AuthenticatedFetchClient extends FetchClient {
           'Content-Type': 'application/json',
         };
 
-        if (method === 'GET') {
-          return await super.get<T>(url, { ...config, headers: retryHeaders, _retry: true });
-        } else {
-          return await super.post<T>(url, data, { ...config, headers: retryHeaders, _retry: true });
+        try {
+          if (method === 'GET') {
+            return await super.get<T>(url, { ...config, headers: retryHeaders, _retry: true });
+          } else {
+            return await super.post<T>(url, data, { ...config, headers: retryHeaders, _retry: true });
+          }
+        } catch (retryError) {
+          logger.error('API request failed after retry', {
+            error: retryError instanceof Error ? retryError.message : String(retryError),
+          });
+          throw retryError;
         }
       }
 

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -40,7 +40,6 @@ export class AuthenticatedFetchClient extends FetchClient {
     logger.info('HTTP request', {
       url,
       method,
-      params: config.params,
     });
 
     try {

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -149,9 +149,8 @@ export class CariotApiAuthProvider {
           statusText: response.statusText,
           body: truncatedBody,
         });
-        throw new Error(
-          `Authentication request failed with status ${response.status}: ${errorBody}`,
-        );
+        // Throw sanitized error to prevent sensitive data from being logged again in catch block
+        throw new Error(`Authentication request failed with status ${response.status}`);
       }
 
       const data = (await response.json()) as ApiAuthResponse;

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -1,6 +1,12 @@
 import { API_BASE } from '../api/api-utils.js';
 import { getEnvironment } from './env.js';
-import { FetchClient, FetchClientError, FetchRequestConfig, FetchResponse } from './http-client.js';
+import {
+  DEFAULT_TIMEOUT_MS,
+  FetchClient,
+  FetchClientError,
+  FetchRequestConfig,
+  FetchResponse,
+} from './http-client.js';
 import { logger } from './logger.js';
 import { ApiAuthResponse, ApiCredentials } from './types.js';
 
@@ -16,7 +22,7 @@ export class AuthenticatedFetchClient extends FetchClient {
 
   constructor(authProvider: CariotApiAuthProvider) {
     super({
-      timeout: 15000,
+      timeout: DEFAULT_TIMEOUT_MS,
       headers: {
         'Content-Type': 'application/json',
       },
@@ -117,7 +123,7 @@ export class CariotApiAuthProvider {
 
   private async fetchToken(): Promise<string> {
     const controller = new AbortController();
-    const timeoutId = globalThis.setTimeout(() => controller.abort(), 15000);
+    const timeoutId = globalThis.setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
 
     try {
       logger.debug('Fetching authentication token', { authType: this.authConfig.type });

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -84,7 +84,7 @@ export class AuthenticatedFetchClient extends FetchClient {
     data?: unknown,
     config?: FetchRequestConfig,
   ): Promise<FetchResponse<T>> {
-    return this.executeWithAuth<T>('POST', url, data, config);
+    return this.executeWithAuth<T>('POST', url, data, config ?? {});
   }
 }
 

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -149,7 +149,9 @@ export class CariotApiAuthProvider {
           body: errorBody,
           loginUrl: this.authConfig.loginUrl,
         });
-        throw new Error(`Authentication request failed with status ${response.status}: ${errorBody}`);
+        throw new Error(
+          `Authentication request failed with status ${response.status}: ${errorBody}`,
+        );
       }
 
       const data = (await response.json()) as ApiAuthResponse;

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -76,7 +76,7 @@ export class AuthenticatedFetchClient extends FetchClient {
   }
 
   async get<T>(url: string, config?: FetchRequestConfig): Promise<FetchResponse<T>> {
-    return this.executeWithAuth<T>('GET', url, undefined, config);
+    return this.executeWithAuth<T>('GET', url, undefined, config ?? {});
   }
 
   async post<T>(

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -110,11 +110,11 @@ export class CariotApiAuthProvider {
   }
 
   private async fetchToken(): Promise<string> {
+    const controller = new AbortController();
+    const timeoutId = globalThis.setTimeout(() => controller.abort(), 15000);
+
     try {
       logger.debug('Fetching authentication token', { authType: this.authConfig.type });
-
-      const controller = new AbortController();
-      const timeoutId = globalThis.setTimeout(() => controller.abort(), 15000);
 
       let response: Response;
 
@@ -138,8 +138,6 @@ export class CariotApiAuthProvider {
           signal: controller.signal,
         });
       }
-
-      globalThis.clearTimeout(timeoutId);
 
       if (!response.ok) {
         const errorBody = await response.text().catch(() => 'Unable to read response body');
@@ -166,6 +164,8 @@ export class CariotApiAuthProvider {
         authType: this.authConfig.type,
       });
       throw new Error(`Failed to authenticate with external API: ${errorMessage}`);
+    } finally {
+      globalThis.clearTimeout(timeoutId);
     }
   }
 

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -163,7 +163,7 @@ export class CariotApiAuthProvider {
         error: errorMessage,
         authType: this.authConfig.type,
       });
-      throw new Error(`Failed to authenticate with external API: ${errorMessage}`);
+      throw new Error('Failed to authenticate with external API');
     } finally {
       globalThis.clearTimeout(timeoutId);
     }

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -49,10 +49,10 @@ export class FetchClient {
   }
 
   private buildUrl(url: string, params?: unknown): string {
-    if (!params) return url;
+    if (!params || typeof params !== 'object' || Array.isArray(params)) return url;
 
     const searchParams = new URLSearchParams();
-    for (const [key, value] of Object.entries(params)) {
+    for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
       if (value !== undefined && value !== null) {
         searchParams.append(key, String(value));
       }

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -9,7 +9,7 @@ export interface FetchClientConfig {
 }
 
 export interface FetchRequestConfig {
-  params?: Record<string, unknown>;
+  params?: unknown;
   headers?: Record<string, string>;
   _retry?: boolean;
 }
@@ -48,7 +48,7 @@ export class FetchClient {
     this.baseHeaders = config.headers ?? {};
   }
 
-  private buildUrl(url: string, params?: Record<string, unknown>): string {
+  private buildUrl(url: string, params?: unknown): string {
     if (!params) return url;
 
     const searchParams = new URLSearchParams();

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -146,7 +146,7 @@ export class FetchClient {
   }
 
   async get<T>(url: string, config?: FetchRequestConfig): Promise<FetchResponse<T>> {
-    return this.request<T>('GET', url, undefined, config);
+    return this.request<T>('GET', url, undefined, config ?? {});
   }
 
   async post<T>(

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -90,12 +90,27 @@ export class FetchClient {
 
     try {
       const response = await fetch(requestUrl, fetchOptions);
-      globalThis.clearTimeout(timeoutId);
 
       let responseData: T;
       const contentType = response.headers.get('content-type');
       if (contentType?.includes('application/json')) {
-        responseData = (await response.json()) as T;
+        try {
+          responseData = (await response.json()) as T;
+        } catch {
+          // JSON parse failed, fallback to text and preserve status info
+          const textBody = await response.text().catch(() => '');
+          const fetchResponse: FetchResponse<unknown> = {
+            data: textBody,
+            status: response.status,
+            headers: response.headers,
+          };
+          throw new FetchClientError(
+            `Failed to parse JSON response (status ${response.status})`,
+            response.status,
+            fetchResponse,
+            { ...config, url, method },
+          );
+        }
       } else {
         responseData = (await response.text()) as unknown as T;
       }
@@ -117,8 +132,6 @@ export class FetchClient {
 
       return fetchResponse;
     } catch (error) {
-      globalThis.clearTimeout(timeoutId);
-
       if (error instanceof FetchClientError) {
         throw error;
       }
@@ -142,6 +155,8 @@ export class FetchClient {
         undefined,
         { ...config, url, method },
       );
+    } finally {
+      globalThis.clearTimeout(timeoutId);
     }
   }
 

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -1,0 +1,167 @@
+/**
+ * HTTP Client using native fetch API
+ * Replaces axios for reduced dependencies and supply chain attack risk
+ */
+
+export interface FetchClientConfig {
+  timeout?: number;
+  headers?: Record<string, string>;
+}
+
+export interface FetchRequestConfig {
+  params?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  _retry?: boolean;
+}
+
+export interface FetchResponse<T> {
+  data: T;
+  status: number;
+  headers: Headers;
+}
+
+export class FetchClientError extends Error {
+  status?: number;
+  response?: FetchResponse<unknown>;
+  config?: FetchRequestConfig & { url?: string; method?: string };
+
+  constructor(
+    message: string,
+    status?: number,
+    response?: FetchResponse<unknown>,
+    config?: FetchRequestConfig & { url?: string; method?: string },
+  ) {
+    super(message);
+    this.name = 'FetchClientError';
+    this.status = status;
+    this.response = response;
+    this.config = config;
+  }
+}
+
+export class FetchClient {
+  private baseHeaders: Record<string, string>;
+  private timeout: number;
+
+  constructor(config: FetchClientConfig = {}) {
+    this.timeout = config.timeout ?? 15000;
+    this.baseHeaders = config.headers ?? {};
+  }
+
+  private buildUrl(url: string, params?: Record<string, unknown>): string {
+    if (!params) return url;
+
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        searchParams.append(key, String(value));
+      }
+    }
+
+    const queryString = searchParams.toString();
+    return queryString ? `${url}?${queryString}` : url;
+  }
+
+  private async request<T>(
+    method: string,
+    url: string,
+    data?: unknown,
+    config: FetchRequestConfig = {},
+  ): Promise<FetchResponse<T>> {
+    const controller = new AbortController();
+    const timeoutId = globalThis.setTimeout(() => controller.abort(), this.timeout);
+
+    const headers: Record<string, string> = {
+      ...this.baseHeaders,
+      ...config.headers,
+    };
+
+    const requestUrl = method === 'GET' ? this.buildUrl(url, config.params) : url;
+
+    const fetchOptions: RequestInit = {
+      method,
+      headers,
+      signal: controller.signal,
+    };
+
+    if (data !== undefined && method !== 'GET') {
+      fetchOptions.body = JSON.stringify(data);
+    }
+
+    try {
+      const response = await fetch(requestUrl, fetchOptions);
+      globalThis.clearTimeout(timeoutId);
+
+      let responseData: T;
+      const contentType = response.headers.get('content-type');
+      if (contentType?.includes('application/json')) {
+        responseData = (await response.json()) as T;
+      } else {
+        responseData = (await response.text()) as unknown as T;
+      }
+
+      const fetchResponse: FetchResponse<T> = {
+        data: responseData,
+        status: response.status,
+        headers: response.headers,
+      };
+
+      if (!response.ok) {
+        throw new FetchClientError(
+          `Request failed with status ${response.status}`,
+          response.status,
+          fetchResponse as FetchResponse<unknown>,
+          { ...config, url, method },
+        );
+      }
+
+      return fetchResponse;
+    } catch (error) {
+      globalThis.clearTimeout(timeoutId);
+
+      if (error instanceof FetchClientError) {
+        throw error;
+      }
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new FetchClientError(
+          `Request timeout after ${this.timeout}ms`,
+          undefined,
+          undefined,
+          {
+            ...config,
+            url,
+            method,
+          },
+        );
+      }
+
+      throw new FetchClientError(
+        error instanceof Error ? error.message : String(error),
+        undefined,
+        undefined,
+        { ...config, url, method },
+      );
+    }
+  }
+
+  async get<T>(url: string, config?: FetchRequestConfig): Promise<FetchResponse<T>> {
+    return this.request<T>('GET', url, undefined, config);
+  }
+
+  async post<T>(
+    url: string,
+    data?: unknown,
+    config?: FetchRequestConfig,
+  ): Promise<FetchResponse<T>> {
+    return this.request<T>('POST', url, data, config);
+  }
+
+  setHeader(key: string, value: string): void {
+    this.baseHeaders[key] = value;
+  }
+
+  getHeaders(): Record<string, string> {
+    return { ...this.baseHeaders };
+  }
+}

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -156,12 +156,4 @@ export class FetchClient {
   ): Promise<FetchResponse<T>> {
     return this.request<T>('POST', url, data, config);
   }
-
-  setHeader(key: string, value: string): void {
-    this.baseHeaders[key] = value;
-  }
-
-  getHeaders(): Record<string, string> {
-    return { ...this.baseHeaders };
-  }
 }

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -154,6 +154,6 @@ export class FetchClient {
     data?: unknown,
     config?: FetchRequestConfig,
   ): Promise<FetchResponse<T>> {
-    return this.request<T>('POST', url, data, config);
+    return this.request<T>('POST', url, data, config ?? {});
   }
 }

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -3,6 +3,9 @@
  * Replaces axios for reduced dependencies and supply chain attack risk
  */
 
+/** Default timeout for HTTP requests in milliseconds */
+export const DEFAULT_TIMEOUT_MS = 15000;
+
 export interface FetchClientConfig {
   timeout?: number;
   headers?: Record<string, string>;
@@ -44,7 +47,7 @@ export class FetchClient {
   private timeout: number;
 
   constructor(config: FetchClientConfig = {}) {
-    this.timeout = config.timeout ?? 15000;
+    this.timeout = config.timeout ?? DEFAULT_TIMEOUT_MS;
     this.baseHeaders = config.headers ?? {};
   }
 

--- a/tests/helpers/mock-factories.ts
+++ b/tests/helpers/mock-factories.ts
@@ -1,21 +1,28 @@
-import { AxiosInstance } from 'axios';
 import { vi } from 'vitest';
 import { CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { FetchClient, FetchResponse } from '../../src/lib/http-client.js';
 
 export function createMockAuthProvider(): CariotApiAuthProvider {
   return {
     getAuthedClient: vi.fn(),
     getValidToken: vi.fn(),
+    clearToken: vi.fn(),
   } as unknown as CariotApiAuthProvider;
 }
 
-export function createMockAxiosClient(): AxiosInstance {
+export function createMockFetchClient(): FetchClient {
   return {
     get: vi.fn(),
     post: vi.fn(),
-    interceptors: {
-      request: { use: vi.fn() },
-      response: { use: vi.fn() },
-    },
-  } as unknown as AxiosInstance;
+    setHeader: vi.fn(),
+    getHeaders: vi.fn().mockReturnValue({}),
+  } as unknown as FetchClient;
+}
+
+export function createMockFetchResponse<T>(data: T, status = 200): FetchResponse<T> {
+  return {
+    data,
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+  };
 }

--- a/tests/helpers/mock-factories.ts
+++ b/tests/helpers/mock-factories.ts
@@ -14,8 +14,6 @@ export function createMockFetchClient(): FetchClient {
   return {
     get: vi.fn(),
     post: vi.fn(),
-    setHeader: vi.fn(),
-    getHeaders: vi.fn().mockReturnValue({}),
   } as unknown as FetchClient;
 }
 

--- a/tests/lib/auth-provider.test.ts
+++ b/tests/lib/auth-provider.test.ts
@@ -1,6 +1,6 @@
-import axios, { AxiosHeaders, AxiosInstance, AxiosRequestConfig } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { AuthenticatedFetchClient, CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { FetchClientError } from '../../src/lib/http-client.js';
 import { logger } from '../../src/lib/logger.js';
 
 vi.mock('../../src/lib/logger.js', () => ({
@@ -26,181 +26,148 @@ describe('CariotApiAuthProvider', () => {
     loginUrl: 'https://example.com/login/cariot',
   };
 
-  interface InterceptableAxiosInstance extends AxiosInstance {
-    __requestInterceptor?: (
-      config: AxiosRequestConfig,
-    ) => Promise<AxiosRequestConfig> | AxiosRequestConfig;
-    __responseErrorInterceptor?: (error: unknown) => Promise<unknown>;
-  }
-
-  let mockClient: InterceptableAxiosInstance;
+  let mockFetch: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
 
-    mockClient = {
-      get: vi.fn(),
-      post: vi.fn(),
-      request: vi.fn(),
-      interceptors: {
-        request: {
-          use: vi.fn(
-            (fn: (cfg: AxiosRequestConfig) => Promise<AxiosRequestConfig> | AxiosRequestConfig) => {
-              mockClient.__requestInterceptor = fn;
-            },
-          ),
-        },
-        response: {
-          use: vi.fn((onFulfilled: unknown, onRejected?: (error: unknown) => unknown) => {
-            if (onRejected) {
-              mockClient.__responseErrorInterceptor = async (error: unknown) => onRejected(error);
-            }
-          }),
-        },
-      },
-    } as unknown as InterceptableAxiosInstance;
-
-    vi.spyOn(axios, 'create').mockReturnValue(mockClient);
-    vi.spyOn(axios, 'post').mockResolvedValue({ data: { api_token: 'token-1' } });
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
   });
 
+  const createMockResponse = (data: unknown, status = 200): Response => {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: vi.fn().mockResolvedValue(data),
+      text: vi.fn().mockResolvedValue(JSON.stringify(data)),
+    } as unknown as Response;
+  };
+
   it('fetches token when none exists and caches it (api_key)', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'token-1' }));
+
     const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
     const token1 = await provider.getValidToken();
     expect(token1).toBe('token-1');
-    expect(axios.post).toHaveBeenCalledTimes(1);
-    expect(axios.post).toHaveBeenCalledWith(
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
       loginUrl,
-      credentials,
-      expect.objectContaining({ headers: { 'Content-Type': 'application/json' }, timeout: 15000 }),
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(credentials),
+      }),
     );
 
-    vi.mocked(axios.post).mockClear();
+    mockFetch.mockClear();
     const token2 = await provider.getValidToken();
     expect(token2).toBe('token-1');
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('fetches token when none exists and caches it (id_token)', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'token-1' }));
+
     const provider = new CariotApiAuthProvider(idTokenAuthConfig);
     const token1 = await provider.getValidToken();
     expect(token1).toBe('token-1');
-    expect(axios.post).toHaveBeenCalledTimes(1);
-    expect(axios.post).toHaveBeenCalledWith(
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
       idTokenAuthConfig.loginUrl,
-      {},
       expect.objectContaining({
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${idTokenAuthConfig.idToken}`,
         },
-        timeout: 15000,
+        body: JSON.stringify({}),
       }),
     );
 
-    vi.mocked(axios.post).mockClear();
+    mockFetch.mockClear();
     const token2 = await provider.getValidToken();
     expect(token2).toBe('token-1');
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('request interceptor sets x-auth-token and content-type', async () => {
+  it('client sets x-auth-token header on requests', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'header-token' }));
+    mockFetch.mockResolvedValueOnce(createMockResponse({ data: 'test' }));
+
     const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
+    const client = provider.getAuthedClient();
 
-    vi.mocked(axios.post).mockResolvedValueOnce({ data: { api_token: 'header-token' } });
+    await client.get('https://api.example.com/test');
 
-    const interceptor = mockClient.__requestInterceptor!;
-    expect(interceptor).toBeTypeOf('function');
-
-    const cfg: AxiosRequestConfig = { url: '/foo', method: 'get', headers: {} };
-    const result = await interceptor(cfg);
-
-    expect(result.headers instanceof AxiosHeaders).toBe(true);
-    const headers = result.headers as AxiosHeaders;
-    expect(headers.get('x-auth-token')).toBe('header-token');
-    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // Second call should be the GET request with auth header
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      'https://api.example.com/test',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'x-auth-token': 'header-token',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
   });
 
-  it('request interceptor preserves AxiosHeaders instance', async () => {
+  it('client retries once on 401 with fresh token', async () => {
+    // First call: fetch token
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'first-token' }));
+    // Second call: API request that returns 401
+    mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'unauthorized' }, 401));
+    // Third call: fetch new token after 401
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'retry-token' }));
+    // Fourth call: retry API request with new token
+    mockFetch.mockResolvedValueOnce(createMockResponse({ data: 'success' }));
+
     const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
+    const client = provider.getAuthedClient();
 
-    vi.mocked(axios.post).mockResolvedValueOnce({ data: { api_token: 'hdr2' } });
+    const response = await client.get('https://api.example.com/secure');
 
-    const interceptor = mockClient.__requestInterceptor!;
-    const initialHeaders = new AxiosHeaders({ 'Content-Type': 'text/plain' });
-    const cfg: AxiosRequestConfig = { url: '/bar', method: 'get', headers: initialHeaders };
-    const result = await interceptor(cfg);
+    expect(response.data).toEqual({ data: 'success' });
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(logger.warn).toHaveBeenCalledWith('Received 401, attempting re-authentication');
 
-    expect(result.headers).toBe(initialHeaders);
-    expect((result.headers as AxiosHeaders).get('x-auth-token')).toBe('hdr2');
-    expect((result.headers as AxiosHeaders).get('Content-Type')).toBe('application/json');
+    // Verify the retry request has the new token
+    const lastCall = mockFetch.mock.calls[3];
+    expect(lastCall[1].headers['x-auth-token']).toBe('retry-token');
   });
 
-  it('response interceptor retries once on 401 with fresh token', async () => {
+  it('client rejects on non-401 without retry', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'token' }));
+    mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'server error' }, 500));
+
     const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
+    const client = provider.getAuthedClient();
 
-    vi.mocked(axios.post).mockResolvedValueOnce({ data: { api_token: 'retry-token' } });
-
-    const retriedResponse = { data: { ok: true } };
-    vi.mocked(mockClient.request).mockResolvedValue(retriedResponse);
-
-    const errorHandler = mockClient.__responseErrorInterceptor!;
-    expect(errorHandler).toBeTypeOf('function');
-
-    const originalConfig: AxiosRequestConfig & { _retry?: boolean } = {
-      url: '/secure',
-      method: 'get',
-      headers: {},
-    };
-
-    const axiosLikeError = {
-      response: { status: 401 },
-      config: originalConfig,
-      message: 'Unauthorized',
-    } as const;
-
-    const out = await errorHandler(axiosLikeError);
-    expect(out).toBe(retriedResponse);
-
-    expect(mockClient.request).toHaveBeenCalledTimes(1);
-    const calledWith = vi.mocked(mockClient.request).mock.calls[0][0] as AxiosRequestConfig & {
-      _retry?: boolean;
-    };
-    expect(calledWith._retry).toBe(true);
-    expect(calledWith.headers).toBeTruthy();
-    const hdrs = calledWith.headers as AxiosHeaders | Record<string, unknown>;
-    expect(hdrs['x-auth-token']).toBe('retry-token');
+    await expect(client.get('https://api.example.com/broken')).rejects.toThrow(FetchClientError);
+    expect(mockFetch).toHaveBeenCalledTimes(2); // token fetch + failed request, no retry
   });
 
-  it('response interceptor rejects on non-401 without retry', async () => {
-    new CariotApiAuthProvider(apiKeyAuthConfig);
-    const errorHandler = mockClient.__responseErrorInterceptor!;
+  it('client does not retry when _retry flag is already set', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'first-token' }));
+    mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'unauthorized' }, 401));
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'retry-token' }));
+    // Simulate the retry also failing with 401
+    mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'still unauthorized' }, 401));
 
-    const axiosLikeError = { response: { status: 500 }, message: 'Server error' } as const;
+    const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
+    const client = provider.getAuthedClient();
 
-    await expect(errorHandler(axiosLikeError)).rejects.toBe(axiosLikeError);
-    expect(mockClient.request).not.toHaveBeenCalled();
-  });
-
-  it('response interceptor rejects when _retry already true', async () => {
-    new CariotApiAuthProvider(apiKeyAuthConfig);
-    const errorHandler = mockClient.__responseErrorInterceptor!;
-
-    const originalConfig: AxiosRequestConfig & { _retry?: boolean } = {
-      url: '/secure',
-      method: 'get',
-      headers: {},
-      _retry: true,
-    };
-    const axiosLikeError = { response: { status: 401 }, config: originalConfig } as const;
-
-    await expect(errorHandler(axiosLikeError)).rejects.toBe(axiosLikeError);
-    expect(mockClient.request).not.toHaveBeenCalled();
+    await expect(client.get('https://api.example.com/secure')).rejects.toThrow(FetchClientError);
+    // Should not attempt a second retry
+    expect(mockFetch).toHaveBeenCalledTimes(4);
   });
 
   it('fetchToken failure bubbles a unified error', async () => {
-    vi.mocked(axios.post).mockRejectedValueOnce(new Error('network down'));
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
     const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
     await expect(provider.getValidToken()).rejects.toThrow(
       'Failed to authenticate with external API',
@@ -212,7 +179,7 @@ describe('CariotApiAuthProvider', () => {
   });
 
   it('logs stringified non-Error when fetchToken fails with non-Error', async () => {
-    vi.mocked(axios.post).mockRejectedValueOnce('string issue');
+    mockFetch.mockRejectedValueOnce('string issue');
     const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
     await expect(provider.getValidToken()).rejects.toThrow(
       'Failed to authenticate with external API',
@@ -223,9 +190,35 @@ describe('CariotApiAuthProvider', () => {
     });
   });
 
-  it('getAuthedClient returns the created axios instance', () => {
+  it('fetchToken fails when response is not ok', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'bad credentials' }, 401));
     const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
-    expect(provider.getAuthedClient()).toBe(mockClient);
+    await expect(provider.getValidToken()).rejects.toThrow(
+      'Failed to authenticate with external API',
+    );
+  });
+
+  it('getAuthedClient returns an AuthenticatedFetchClient instance', () => {
+    const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
+    const client = provider.getAuthedClient();
+    expect(client).toBeInstanceOf(AuthenticatedFetchClient);
+    // Same instance should be returned on subsequent calls
+    expect(provider.getAuthedClient()).toBe(client);
+  });
+
+  it('clearToken clears the cached token', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'token-1' }));
+    mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'token-2' }));
+
+    const provider = new CariotApiAuthProvider(apiKeyAuthConfig);
+    const token1 = await provider.getValidToken();
+    expect(token1).toBe('token-1');
+
+    provider.clearToken();
+
+    const token2 = await provider.getValidToken();
+    expect(token2).toBe('token-2');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it('createCariotAuthProvider constructs with env credentials (api_key)', () => {

--- a/tests/lib/auth-provider.test.ts
+++ b/tests/lib/auth-provider.test.ts
@@ -36,6 +36,10 @@ describe('CariotApiAuthProvider', () => {
     vi.stubGlobal('fetch', mockFetch);
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   const createMockResponse = (data: unknown, status = 200): Response => {
     return {
       ok: status >= 200 && status < 300,

--- a/tests/lib/auth-provider.test.ts
+++ b/tests/lib/auth-provider.test.ts
@@ -155,7 +155,7 @@ describe('CariotApiAuthProvider', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2); // token fetch + failed request, no retry
   });
 
-  it('client does not retry when _retry flag is already set', async () => {
+  it('client retries at most once when retry also returns 401', async () => {
     mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'first-token' }));
     mockFetch.mockResolvedValueOnce(createMockResponse({ error: 'unauthorized' }, 401));
     mockFetch.mockResolvedValueOnce(createMockResponse({ api_token: 'retry-token' }));
@@ -166,7 +166,7 @@ describe('CariotApiAuthProvider', () => {
     const client = provider.getAuthedClient();
 
     await expect(client.get('https://api.example.com/secure')).rejects.toThrow(FetchClientError);
-    // Should not attempt a second retry
+    // token fetch + 401 + token refresh + retry 401 = 4 calls, no second retry
     expect(mockFetch).toHaveBeenCalledTimes(4);
   });
 

--- a/tests/toolsets/analyze-alcohol-checks-toolset.test.ts
+++ b/tests/toolsets/analyze-alcohol-checks-toolset.test.ts
@@ -1,9 +1,9 @@
-import { AxiosInstance } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { FetchClient } from '../../src/lib/http-client.js';
 import { analyzeAlcoholChecksTool } from '../../src/toolsets/analyze-alcohol-checks-toolset.js';
 import { formatConfig } from '../../src/toolsets/base-toolset.js';
-import { createMockAuthProvider, createMockAxiosClient } from '../helpers/mock-factories.js';
+import { createMockAuthProvider, createMockFetchClient } from '../helpers/mock-factories.js';
 
 vi.mock('../../src/api/get-daily-reports.js', () => ({
   getDailyReports: vi.fn(),
@@ -18,11 +18,11 @@ describe('AnalyzeAlcoholChecksToolset', () => {
     handler: ReturnType<typeof analyzeAlcoholChecksTool.handler>;
   };
   let mockAuthProvider: CariotApiAuthProvider;
-  let mockClient: AxiosInstance;
+  let mockClient: FetchClient;
 
   beforeEach(() => {
     mockAuthProvider = createMockAuthProvider();
-    mockClient = createMockAxiosClient();
+    mockClient = createMockFetchClient();
     registration = {
       name: analyzeAlcoholChecksTool.name,
       config: formatConfig(analyzeAlcoholChecksTool.config),

--- a/tests/toolsets/generate-chart-config-toolset.test.ts
+++ b/tests/toolsets/generate-chart-config-toolset.test.ts
@@ -1,9 +1,9 @@
-import { AxiosInstance } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { FetchClient } from '../../src/lib/http-client.js';
 import { formatConfig } from '../../src/toolsets/base-toolset.js';
 import { generateChartConfigTool } from '../../src/toolsets/generate-chart-config-toolset.js';
-import { createMockAuthProvider, createMockAxiosClient } from '../helpers/mock-factories.js';
+import { createMockAuthProvider, createMockFetchClient } from '../helpers/mock-factories.js';
 
 describe('GenerateChartConfigToolset', () => {
   let registration: {
@@ -12,11 +12,11 @@ describe('GenerateChartConfigToolset', () => {
     handler: ReturnType<typeof generateChartConfigTool.handler>;
   };
   let mockAuthProvider: CariotApiAuthProvider;
-  let mockClient: AxiosInstance;
+  let mockClient: FetchClient;
 
   beforeEach(() => {
     mockAuthProvider = createMockAuthProvider();
-    mockClient = createMockAxiosClient();
+    mockClient = createMockFetchClient();
     registration = {
       name: generateChartConfigTool.name,
       config: formatConfig(generateChartConfigTool.config),

--- a/tests/toolsets/get-daily-report-toolset.test.ts
+++ b/tests/toolsets/get-daily-report-toolset.test.ts
@@ -1,9 +1,9 @@
-import { AxiosInstance } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { FetchClient } from '../../src/lib/http-client.js';
 import { formatConfig } from '../../src/toolsets/base-toolset.js';
 import { dailyReportTool } from '../../src/toolsets/get-daily-report-toolset.js';
-import { createMockAuthProvider, createMockAxiosClient } from '../helpers/mock-factories.js';
+import { createMockAuthProvider, createMockFetchClient } from '../helpers/mock-factories.js';
 
 vi.mock('../../src/api/get-daily-report.js', () => ({
   getDailyReport: vi.fn(),
@@ -18,11 +18,11 @@ describe('GetDailyReportToolset', () => {
     handler: ReturnType<typeof dailyReportTool.handler>;
   };
   let mockAuthProvider: CariotApiAuthProvider;
-  let mockClient: AxiosInstance;
+  let mockClient: FetchClient;
 
   beforeEach(() => {
     mockAuthProvider = createMockAuthProvider();
-    mockClient = createMockAxiosClient();
+    mockClient = createMockFetchClient();
     registration = {
       name: dailyReportTool.name,
       config: formatConfig(dailyReportTool.config),

--- a/tests/toolsets/get-daily-reports-toolset.test.ts
+++ b/tests/toolsets/get-daily-reports-toolset.test.ts
@@ -1,9 +1,9 @@
-import { AxiosInstance } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { FetchClient } from '../../src/lib/http-client.js';
 import { formatConfig } from '../../src/toolsets/base-toolset.js';
 import { dailyReportsTool } from '../../src/toolsets/get-daily-reports-toolset.js';
-import { createMockAuthProvider, createMockAxiosClient } from '../helpers/mock-factories.js';
+import { createMockAuthProvider, createMockFetchClient } from '../helpers/mock-factories.js';
 
 vi.mock('../../src/api/get-daily-reports.js', () => ({
   getDailyReports: vi.fn(),
@@ -19,11 +19,11 @@ describe('GetDailyReportsToolset', () => {
     handler: ReturnType<typeof dailyReportsTool.handler>;
   };
   let mockAuthProvider: CariotApiAuthProvider;
-  let mockClient: AxiosInstance;
+  let mockClient: FetchClient;
 
   beforeEach(() => {
     mockAuthProvider = createMockAuthProvider();
-    mockClient = createMockAxiosClient();
+    mockClient = createMockFetchClient();
     registration = {
       name: dailyReportsTool.name,
       config: formatConfig(dailyReportsTool.config),

--- a/tests/toolsets/get-drivers-toolset.test.ts
+++ b/tests/toolsets/get-drivers-toolset.test.ts
@@ -1,9 +1,9 @@
-import { AxiosInstance } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { FetchClient } from '../../src/lib/http-client.js';
 import { formatConfig } from '../../src/toolsets/base-toolset.js';
 import { driversTool } from '../../src/toolsets/get-drivers-toolset.js';
-import { createMockAuthProvider, createMockAxiosClient } from '../helpers/mock-factories.js';
+import { createMockAuthProvider, createMockFetchClient } from '../helpers/mock-factories.js';
 
 vi.mock('../../src/api/get-drivers.js', () => ({
   getDrivers: vi.fn(),
@@ -19,11 +19,11 @@ describe('GetDriversToolset', () => {
     handler: ReturnType<typeof driversTool.handler>;
   };
   let mockAuthProvider: CariotApiAuthProvider;
-  let mockClient: AxiosInstance;
+  let mockClient: FetchClient;
 
   beforeEach(() => {
     mockAuthProvider = createMockAuthProvider();
-    mockClient = createMockAxiosClient();
+    mockClient = createMockFetchClient();
     registration = {
       name: driversTool.name,
       config: formatConfig(driversTool.config),

--- a/tests/toolsets/get-realtime-toolset.test.ts
+++ b/tests/toolsets/get-realtime-toolset.test.ts
@@ -1,9 +1,9 @@
-import { AxiosInstance } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { FetchClient } from '../../src/lib/http-client.js';
 import { formatConfig } from '../../src/toolsets/base-toolset.js';
 import { realtimeTool } from '../../src/toolsets/get-realtime-toolset.js';
-import { createMockAuthProvider, createMockAxiosClient } from '../helpers/mock-factories.js';
+import { createMockAuthProvider, createMockFetchClient } from '../helpers/mock-factories.js';
 
 vi.mock('../../src/api/get-device-snapshots.js', () => ({
   getDeviceSnapshots: vi.fn(),
@@ -18,11 +18,11 @@ describe('GetRealtimeToolset', () => {
     handler: ReturnType<typeof realtimeTool.handler>;
   };
   let mockAuthProvider: CariotApiAuthProvider;
-  let mockClient: AxiosInstance;
+  let mockClient: FetchClient;
 
   beforeEach(() => {
     mockAuthProvider = createMockAuthProvider();
-    mockClient = createMockAxiosClient();
+    mockClient = createMockFetchClient();
     registration = {
       name: realtimeTool.name,
       config: formatConfig(realtimeTool.config),

--- a/tests/toolsets/get-vehicles-toolset.test.ts
+++ b/tests/toolsets/get-vehicles-toolset.test.ts
@@ -1,9 +1,9 @@
-import { AxiosInstance } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CariotApiAuthProvider } from '../../src/lib/auth-provider.js';
+import { FetchClient } from '../../src/lib/http-client.js';
 import { formatConfig } from '../../src/toolsets/base-toolset.js';
 import { vehiclesTool } from '../../src/toolsets/get-vehicles-toolset.js';
-import { createMockAuthProvider, createMockAxiosClient } from '../helpers/mock-factories.js';
+import { createMockAuthProvider, createMockFetchClient } from '../helpers/mock-factories.js';
 
 vi.mock('../../src/api/get-vehicles.js', () => ({
   getVehicles: vi.fn(),
@@ -19,11 +19,11 @@ describe('GetVehiclesToolset', () => {
     handler: ReturnType<typeof vehiclesTool.handler>;
   };
   let mockAuthProvider: CariotApiAuthProvider;
-  let mockClient: AxiosInstance;
+  let mockClient: FetchClient;
 
   beforeEach(() => {
     mockAuthProvider = createMockAuthProvider();
-    mockClient = createMockAxiosClient();
+    mockClient = createMockFetchClient();
     registration = {
       name: vehiclesTool.name,
       config: formatConfig(vehiclesTool.config),


### PR DESCRIPTION
## Overview

Replaced axios with the native Node.js fetch API to resolve vulnerabilities detected by npm audit.

### Changes

- Remove axios library and create new `FetchClient` class based on fetch API
- Implement `AuthenticatedFetchClient` class for axios interceptor-equivalent auth handling
  - Token injection before requests
  - Automatic retry on 401 errors (once only)
- Add detailed error logging for authentication failures
- Fix MCP SDK v1.21.1 API change (remove deprecated `capabilities` option)
- Update dependencies via npm audit fix

### Verification

- `npm audit`: 0 vulnerabilities
- `npm test`: All 80 tests passed
- `npm run lint`: No errors
- Manual testing: Confirmed vehicle list retrieval and driver list retrieval work correctly